### PR TITLE
Added a type cast to avoid compilation error

### DIFF
--- a/src/cunit/ut_cunit.c
+++ b/src/cunit/ut_cunit.c
@@ -180,7 +180,7 @@ const char *UT_getTestSuiteTitle( UT_test_suite_t *pSuite )
 {
     CU_pTest pTest;
 
-    pTest = pSuite;
+    pTest = (CU_pTest)pSuite;
 
     return pTest->pName;
 }


### PR DESCRIPTION
Added the changes of type cast to avoid compilation error.

diff --git a/src/cunit/ut_cunit.c b/src/cunit/ut_cunit.c
index 1df5290..179ccc4 100644
--- a/src/cunit/ut_cunit.c
+++ b/src/cunit/ut_cunit.c
@@ -180,7 +180,7 @@ const char *UT_getTestSuiteTitle( UT_test_suite_t *pSuite )
{
  CU_pTest pTest;
  -pTest = pSuite;
  +pTest = (CU_pTest)pSuite;
  return pTest->pName;
}