### PR TITLE
GH81: removing BIN directory as part of the cleanall rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,9 @@ clean:
 cleanall: clean 
 	@echo -e ${GREEN}Performing Clean on frameworks [$(UT_CORE_DIR)/framework]${NC}
 	@$(RM) -rf $(UT_CORE_DIR)/framework
-	@$(RM) -rf $(BIN_DIR)
+	@$(RM) -rf $(BIN_DIR)/lib*.so*
+	@$(RM) -rf $(BIN_DIR)/lib*.a
+	@$(RM) -rf $(BIN_DIR)/$(TARGET_EXEC)
 
 list:
 	@echo --------- ut_core ----------------

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ clean:
 cleanall: clean 
 	@echo -e ${GREEN}Performing Clean on frameworks [$(UT_CORE_DIR)/framework]${NC}
 	@$(RM) -rf $(UT_CORE_DIR)/framework
+	@$(RM) -rf $(BIN_DIR)
 
 list:
 	@echo --------- ut_core ----------------


### PR DESCRIPTION
PR to remove libraries and executables from BIN directory during cleanall execution.