### PR TITLE
PR: gh#127 : Fixed few issues listed on the ticket 

### DIFF
--- a/scripts/autogenerate.sh
+++ b/scripts/autogenerate.sh
@@ -127,7 +127,7 @@ function AGT_clone_doxygen_repo()
 	if [ ! -d "${AGT_DOXYGEN_DIR}"  ]; then
 		# Clone doxygen template into doxy dir in workspace/api-def dir
 		git clone git@github.com:rdkcentral/hal-doxygen.git ${AGT_DOXYGEN_DIR} &> /dev/null
-		AGT_SUCCESS "Doxygen repo has been cloned in [../workspace/${AGT_DOXYGEN_REPO_NAME}]"
+		AGT_SUCCESS "Doxygen repo has been cloned in [${AGT_UT_WORKSPACE_RELATIVE_PATH}/${AGT_DOXYGEN_REPO_NAME}]"
 	fi
 
 	cd ${AGT_SCRIPTS_HOME}
@@ -304,7 +304,7 @@ AGT_generate_all()
 	# Create workspace if it doesn't exist already
 	AGT_DEBUG_START "Creating Workspace"
 	mkdir -p ${AGT_UT_WORKSPACE}
-	AGT_SUCCESS "Workspace directory available at [../workspace/]"
+	AGT_SUCCESS "Workspace directory available at [${AGT_UT_WORKSPACE_RELATIVE_PATH}]"
 
 	AGT_DEBUG_END "Creating Workspace"
     if [ ! -d "$url" ]; then
@@ -327,7 +327,7 @@ AGT_generate_all()
 	./autogenerate_tests.sh ${AGT_APIDEF_URL} ${AGT_DEBUG}
 	echo -e ""
 	AGT_ALERT "PLEASE REVIEW, SELECT, EDIT AND COMMIT AS REQUIRED"
-	AGT_ALERT "GENERATED TESTS AVAILABLE IN ${PURPLE}[../workspace/${AGT_APIDEF_NAME}/ut/src]"
+	AGT_ALERT "GENERATED TESTS AVAILABLE IN ${PURPLE}[${AGT_UT_WORKSPACE_RELATIVE_PATH}/${AGT_APIDEF_NAME}/ut/src]"
 }
 
 # Clear workspace dir

--- a/scripts/autogenerate_shared.sh
+++ b/scripts/autogenerate_shared.sh
@@ -60,7 +60,8 @@ function AGT_commons_init()
         # Base dir of where the scripts are in ut-core
         AGT_BASEDIR=${AGT_SCRIPTS_HOME}/..
         # Workspace dir in ut-core where the script generates the tests
-        AGT_UT_WORKSPACE=${AGT_BASEDIR}/workspace
+        AGT_UT_WORKSPACE=${AGT_SCRIPTS_HOME}/workspace
+        AGT_UT_WORKSPACE_RELATIVE_PATH="./workspace"
         # API Definition name inside the worksapce dir
         AGT_APIDEF_NAME=`echo ${1##*/}| cut -d'.' -f1`
         # Base URL for git repos
@@ -76,8 +77,8 @@ function AGT_commons_init()
         # API Definition home inside the worksapce dir
         AGT_APIDEF_HOME=${AGT_UT_WORKSPACE}/${AGT_APIDEF_NAME}
         # Include dir inside worksapce dir
-        if [ ! -z "$(ls ${AGT_APIDEF_HOME}/include/*.h &> /dev/null)" ]; then
-                AGT_INCLUDE_DIR=${AGT_APIDEF_HOME}/include
+        if [ -d "${AGT_APIDEF_HOME}/include/" ]; then
+                AGT_INCLUDE_DIR="${AGT_APIDEF_HOME}/include"
         else
                 AGT_APIDEF_HEADER_FILES=$(find ${AGT_APIDEF_HOME} -type f -name "*.h" -print0 2> /dev/null | tr '\0' ' ')
         fi

--- a/scripts/autogenerate_skeletons.sh
+++ b/scripts/autogenerate_skeletons.sh
@@ -90,8 +90,8 @@ function AGT_generate_skeletons()
 
         # Run the skeleton generate command
         cd ${AGT_UT_HOME}
-        if [[ -n $AGT_INCLUDE_DIR ]]; then
-                HEADER_FILES=${AGT_INCLUDE_DIR}/*.h
+        if [ -n "${AGT_INCLUDE_DIR}" ] && [ -d "${AGT_INCLUDE_DIR}" ]; then
+                HEADER_FILES=$(ls "${AGT_INCLUDE_DIR}"/*.h)
         else
                 HEADER_FILES=${AGT_APIDEF_HEADER_FILES}
         fi
@@ -130,6 +130,7 @@ function AGT_set_up_skeletons()
                 AGT_DEBUG_START "Deleting skeletons' src files"
                 rm ${AGT_SKELETONS_SRC}/*
                 AGT_DEBUG_END "Deleting skeletons' src files"
+                AGT_WARNING "Deleted skeletons' original src files"
         fi
 }
 

--- a/scripts/test_autogenerate_script.sh
+++ b/scripts/test_autogenerate_script.sh
@@ -94,6 +94,10 @@ sleep 2
 run_command 'echo "y" | ./autogenerate.sh https://github.com/rdkcentral/RdkWanManager.git -b RDKB-56270-gtest'
 run_command './autogenerate.sh -c'
 
+#Test 7
+run_command 'echo "y" | ./autogenerate.sh https://github.com/rdkcentral/rdkb-halif-wifi'
+run_command './autogenerate.sh -c'
+
 # Display consolidated results
 echo
 echo "Total tests run: $total_tests"


### PR DESCRIPTION
Fixed following issues:

1. The workspace path needs to be ./workspace, not ../workspace
2. skeletons dir needs to be generated, even if it exists or doesn't exist
3. The scripts fails on https://github.com/rdkcentral/rdkb-halif-wifi



Logs below:
```
$ ./test_autogenerate_script.sh 
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Processing git URL: git@github.com:rdkcentral/rdk-halif-device_settings.git
Workspace directory available at [./workspace]
 The url for UT clone is : git@github.com:rdkcentral/rdk-halif-test-device_settings.git 
Original UT url is 'git@github.com:rdkcentral/rdk-halif-test-device_settings.git'
UT repo is now cloned/copied
The mocks directory does NOT EXIST   
The skeletons' src directory IS NOT EMPTY
Deleted skeletons' original src files
Successfully installed gems in 'vendor/bundle'.
CMock is now installed
Skeletons are generated successfully
L1 and L2 tests for 'dsAudio.h' is created 

L1 and L2 tests for 'dsCompositeIn.h' is created 

L1 and L2 tests for 'dsDisplay.h' is created 

L1 and L2 tests for 'dsFPD.h' is created 

L1 and L2 tests for 'dsHdmiIn.h' is created 

L1 and L2 tests for 'dsHost.h' is created 

L1 and L2 tests for 'dsVideoDevice.h' is created 

L1 and L2 tests for 'dsVideoPort.h' is created 


PLEASE REVIEW, SELECT, EDIT AND COMMIT AS REQUIRED   
GENERATED TESTS AVAILABLE IN [./workspace/rdk-halif-device_settings/ut/src]   
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Processing git URL: https://github.com/rdkcentral/RdkWanManager.git
Workspace directory available at [./workspace]
Doxygen repo has been cloned in [./workspace/hal-doxygen]
 The url for UT clone is : https://github.com/rdkcentral/RdkWanManager.git 
Original UT url is 'https://github.com/rdkcentral/RdkWanManager.git'
UT repo is now cloned/copied
The mocks directory does NOT EXIST   
Successfully installed gems in 'vendor/bundle'.
CMock is now installed
Skeletons are generated successfully
L1 and L2 tests for 'wanmgr_bus_utils.h' is created 

L1 and L2 tests for 'wanmgr_controller.h' is created 

L1 and L2 tests for 'wanmgr_core.h' is created 

L1 and L2 tests for 'wanmgr_data.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_internal.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_internal.h' is created 

L1 and L2 tests for 'wanmgr_dml_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv4.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv6.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_v2_apis.h' is created 

L1 and L2 tests for 'wanmgr_interface_sm.h' is created 

L1 and L2 tests for 'wanmgr_ipc.h' is created 

L1 and L2 tests for 'wanmgr_net_utils.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main_apis.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main.h' is created 

L1 and L2 tests for 'wanmgr_rbus_handler_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_common.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_utils.h' is created 

L1 and L2 tests for 'wanmgr_ssp_internal.h' is created 

L1 and L2 tests for 'wanmgr_ssp_messagebus_interface.h' is created 

L1 and L2 tests for 'wanmgr_sysevents.h' is created 

L1 and L2 tests for 'wanmgr_utils.h' is created 

L1 and L2 tests for 'wanmgr_wan_failover.h' is created 

L1 and L2 tests for 'wanmgr_webconfig_apis.h' is created 

L1 and L2 tests for 'wanmgr_webconfig.h' is created 


PLEASE REVIEW, SELECT, EDIT AND COMMIT AS REQUIRED   
GENERATED TESTS AVAILABLE IN [./workspace/RdkWanManager/ut/src]   
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Cloning into 'rdkwanmanager'...
remote: Enumerating objects: 4425, done.
remote: Counting objects: 100% (2223/2223), done.
remote: Compressing objects: 100% (925/925), done.
remote: Total 4425 (delta 1677), reused 1422 (delta 1298), pack-reused 2202 (from 1)
Receiving objects: 100% (4425/4425), 2.46 MiB | 28.97 MiB/s, done.
Resolving deltas: 100% (2925/2925), done.
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Processing directory path: /home/jpn323/workspace/gh127-fix-script/scripts/rdkwanmanager
Workspace directory available at [./workspace]
Doxygen repo has been cloned in [./workspace/hal-doxygen]
 The url for UT clone is : /home/jpn323/workspace/gh127-fix-script/scripts/rdkwanmanager 
Original UT url is '/home/jpn323/workspace/gh127-fix-script/scripts/rdkwanmanager'
UT repo is now cloned/copied
The mocks directory does NOT EXIST   
Successfully installed gems in 'vendor/bundle'.
CMock is now installed
Skeletons are generated successfully
L1 and L2 tests for 'wanmgr_bus_utils.h' is created 

L1 and L2 tests for 'wanmgr_controller.h' is created 

L1 and L2 tests for 'wanmgr_core.h' is created 

L1 and L2 tests for 'wanmgr_data.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_internal.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_internal.h' is created 

L1 and L2 tests for 'wanmgr_dml_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv4.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv6.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_v2_apis.h' is created 

L1 and L2 tests for 'wanmgr_interface_sm.h' is created 

L1 and L2 tests for 'wanmgr_ipc.h' is created 

L1 and L2 tests for 'wanmgr_net_utils.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main_apis.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main.h' is created 

L1 and L2 tests for 'wanmgr_rbus_handler_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_common.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_utils.h' is created 

L1 and L2 tests for 'wanmgr_ssp_internal.h' is created 

L1 and L2 tests for 'wanmgr_ssp_messagebus_interface.h' is created 

L1 and L2 tests for 'wanmgr_sysevents.h' is created 

L1 and L2 tests for 'wanmgr_utils.h' is created 

L1 and L2 tests for 'wanmgr_wan_failover.h' is created 

L1 and L2 tests for 'wanmgr_webconfig_apis.h' is created 

L1 and L2 tests for 'wanmgr_webconfig.h' is created 


PLEASE REVIEW, SELECT, EDIT AND COMMIT AS REQUIRED   
GENERATED TESTS AVAILABLE IN [./workspace/rdkwanmanager/ut/src]   
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Processing git URL: https://github.com/rdkcentral/RdkWanManager.git
Workspace directory available at [./workspace]
Doxygen repo has been cloned in [./workspace/hal-doxygen]
 The url for UT clone is : https://github.com/rdkcentral/RdkWanManager.git 
UT url is 'https://github.com/rdkcentral/RdkWanManager.git'
UT repo is now cloned/copied
The mocks directory does NOT EXIST   
Successfully installed gems in 'vendor/bundle'.
CMock is now installed
Skeletons are generated successfully
L1 and L2 tests for 'wanmgr_bus_utils.h' is created 

L1 and L2 tests for 'wanmgr_controller.h' is created 

L1 and L2 tests for 'wanmgr_core.h' is created 

L1 and L2 tests for 'wanmgr_data.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_internal.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_internal.h' is created 

L1 and L2 tests for 'wanmgr_dml_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv4.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv6.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_v2_apis.h' is created 

L1 and L2 tests for 'wanmgr_interface_sm.h' is created 

L1 and L2 tests for 'wanmgr_ipc.h' is created 

L1 and L2 tests for 'wanmgr_net_utils.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main_apis.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main.h' is created 

L1 and L2 tests for 'wanmgr_rbus_handler_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_common.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_utils.h' is created 

L1 and L2 tests for 'wanmgr_ssp_internal.h' is created 

L1 and L2 tests for 'wanmgr_ssp_messagebus_interface.h' is created 

L1 and L2 tests for 'wanmgr_sysevents.h' is created 

L1 and L2 tests for 'wanmgr_utils.h' is created 

L1 and L2 tests for 'wanmgr_wan_failover.h' is created 

L1 and L2 tests for 'wanmgr_webconfig_apis.h' is created 

L1 and L2 tests for 'wanmgr_webconfig.h' is created 


PLEASE REVIEW, SELECT, EDIT AND COMMIT AS REQUIRED   
GENERATED TESTS AVAILABLE IN [./workspace/RdkWanManager/ut/src]   
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Cloning into 'rdkwanmanager'...
remote: Enumerating objects: 4425, done.
remote: Counting objects: 100% (2340/2340), done.
remote: Compressing objects: 100% (928/928), done.
remote: Total 4425 (delta 1796), reused 1536 (delta 1412), pack-reused 2085 (from 1)
Receiving objects: 100% (4425/4425), 2.46 MiB | 31.11 MiB/s, done.
Resolving deltas: 100% (2926/2926), done.
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Processing git URL: https://github.com/rdkcentral/RdkWanManager.git
Workspace directory available at [./workspace]
Doxygen repo has been cloned in [./workspace/hal-doxygen]
 The url for UT clone is : https://github.com/rdkcentral/RdkWanManager.git 
UT directory path is '/home/jpn323/workspace/gh127-fix-script/scripts/rdkwanmanager'
UT repo is now cloned/copied
The mocks directory does NOT EXIST   
Successfully installed gems in 'vendor/bundle'.
CMock is now installed
Skeletons are generated successfully
L1 and L2 tests for 'wanmgr_bus_utils.h' is created 

L1 and L2 tests for 'wanmgr_controller.h' is created 

L1 and L2 tests for 'wanmgr_core.h' is created 

L1 and L2 tests for 'wanmgr_data.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_internal.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_internal.h' is created 

L1 and L2 tests for 'wanmgr_dml_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv4.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv6.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_v2_apis.h' is created 

L1 and L2 tests for 'wanmgr_interface_sm.h' is created 

L1 and L2 tests for 'wanmgr_ipc.h' is created 

L1 and L2 tests for 'wanmgr_net_utils.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main_apis.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main.h' is created 

L1 and L2 tests for 'wanmgr_rbus_handler_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_common.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_utils.h' is created 

L1 and L2 tests for 'wanmgr_ssp_internal.h' is created 

L1 and L2 tests for 'wanmgr_ssp_messagebus_interface.h' is created 

L1 and L2 tests for 'wanmgr_sysevents.h' is created 

L1 and L2 tests for 'wanmgr_utils.h' is created 

L1 and L2 tests for 'wanmgr_wan_failover.h' is created 

L1 and L2 tests for 'wanmgr_webconfig_apis.h' is created 

L1 and L2 tests for 'wanmgr_webconfig.h' is created 


PLEASE REVIEW, SELECT, EDIT AND COMMIT AS REQUIRED   
GENERATED TESTS AVAILABLE IN [./workspace/RdkWanManager/ut/src]   
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Processing git URL: https://github.com/rdkcentral/RdkWanManager.git
Workspace directory available at [./workspace]
Branch [RDKB-56270-gtest] is now checked out
Doxygen repo has been cloned in [./workspace/hal-doxygen]
 The url for UT clone is : https://github.com/rdkcentral/RdkWanManager.git 
Original UT url is 'https://github.com/rdkcentral/RdkWanManager.git'
UT repo is now cloned/copied
The mocks directory does NOT EXIST   
Successfully installed gems in 'vendor/bundle'.
CMock is now installed
Skeletons are generated successfully
L1 and L2 tests for 'wanmgr_bus_utils.h' is created 

L1 and L2 tests for 'wanmgr_controller.h' is created 

L1 and L2 tests for 'wanmgr_core.h' is created 

L1 and L2 tests for 'wanmgr_data.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv4_internal.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_apis.h' is created 

L1 and L2 tests for 'wanmgr_dhcpv6_internal.h' is created 

L1 and L2 tests for 'wanmgr_dml_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv4.h' is created 

L1 and L2 tests for 'wanmgr_dml_dhcpv6.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_apis.h' is created 

L1 and L2 tests for 'wanmgr_dml_iface_v2_apis.h' is created 

L1 and L2 tests for 'wanmgr_interface_sm.h' is created 

L1 and L2 tests for 'wanmgr_ipc.h' is created 

L1 and L2 tests for 'wanmgr_net_utils.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main_apis.h' is created 

L1 and L2 tests for 'wanmgr_plugin_main.h' is created 

L1 and L2 tests for 'wanmgr_rbus_handler_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_apis.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_common.h' is created 

L1 and L2 tests for 'wanmgr_rdkbus_utils.h' is created 

L1 and L2 tests for 'wanmgr_ssp_internal.h' is created 

L1 and L2 tests for 'wanmgr_ssp_messagebus_interface.h' is created 

L1 and L2 tests for 'wanmgr_sysevents.h' is created 

L1 and L2 tests for 'wanmgr_utils.h' is created 

L1 and L2 tests for 'wanmgr_wan_failover.h' is created 

L1 and L2 tests for 'wanmgr_webconfig_apis.h' is created 

L1 and L2 tests for 'wanmgr_webconfig.h' is created 


PLEASE REVIEW, SELECT, EDIT AND COMMIT AS REQUIRED   
GENERATED TESTS AVAILABLE IN [./workspace/RdkWanManager/ut/src]   
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc
Processing git URL: https://github.com/rdkcentral/rdkb-halif-wifi
Workspace directory available at [./workspace]
Doxygen repo has been cloned in [./workspace/hal-doxygen]
 The url for UT clone is : https://github.com/rdkcentral/rdkb-halif-test-wifi 
Original UT url is 'https://github.com/rdkcentral/rdkb-halif-test-wifi'
UT repo is now cloned/copied
The mocks directory is now DELETED
The skeletons' src directory IS NOT EMPTY
Deleted skeletons' original src files
Successfully installed gems in 'vendor/bundle'.
CMock is now installed
Skeletons are generated successfully
L1 and L2 tests for 'wifi_hal_ap.h' is created 

L1 and L2 tests for 'wifi_hal_extender.h' is created 

L1 and L2 tests for 'wifi_hal_generic.h' is created 

L1 and L2 tests for 'wifi_hal_radio.h' is created 

L1 and L2 tests for 'wifi_hal_sta.h' is created 

L1 and L2 tests for 'wifi_hal_telemetry.h' is created 


PLEASE REVIEW, SELECT, EDIT AND COMMIT AS REQUIRED   
GENERATED TESTS AVAILABLE IN [./workspace/rdkb-halif-wifi/ut/src]   
Ruby version 2.7.0p0 meets the minimum requirement of 2.7.0.
Bundler version 2.4.17 meets the minimum requirement of 2.4.17.
All version checks passed.
Also make sure that you have access to all the git repos like rdkcentral etc

Total tests run: 14
Successful tests: 14
Failed tests: 0

*************************************
All commands executed successfully.
*************************************
``` 