### PR TITLE
gh #190 Edge case issue on dunfell with TARGET=linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -144,7 +144,7 @@ if [[ ! -d "${GTEST_DIR}/googletest-${GTEST_VERSION}" && "${VARIANT}" == "CPP" ]
     fi
     mkdir -p ${GTEST_LIB_DIR}
     cd ${GTEST_LIB_DIR}
-    if command -v cmake &> /dev/null; then
+    if command -v cmake &> /dev/null && [ "$(cmake --version | head -n1 | awk '{print $3}')" \> "3.12" ]; then
         cmake "${GTEST_DIR}/googletest-${GTEST_VERSION}/"
     else
         CMAKE_BIN=$(find ${UT_CONTROL_LIB_DIR} -name cmake -type f | grep '/bin/')

--- a/build.sh
+++ b/build.sh
@@ -144,6 +144,8 @@ if [[ ! -d "${GTEST_DIR}/googletest-${GTEST_VERSION}" && "${VARIANT}" == "CPP" ]
     fi
     mkdir -p ${GTEST_LIB_DIR}
     cd ${GTEST_LIB_DIR}
+
+    # Prefer system cmake if version is > 3.12
     if command -v cmake &> /dev/null && [ "$(cmake --version | head -n1 | awk '{print $3}')" \> "3.12" ]; then
         cmake "${GTEST_DIR}/googletest-${GTEST_VERSION}/"
     else


### PR DESCRIPTION
**Problem/Opportunity**
When running ut-core on dunfell linux found following issue:
The cmake installed is 3.10.2 but gtest requires 3.13 or above.
As the CMAKE is already installed, ut-core wouldn't install CMAKE for itself and would fallback on installed CMAKE. Since, the installed version is 3.10.2 gtest build fails in this scenario.

```
inflating: googletest-1.15.2/googletest_deps.bzl  
CMake Error at CMakeLists.txt:4 (cmake_minimum_required):
  CMake 3.13 or higher is required.  You are running version 3.10.2
```

```
-- Configuring incomplete, errors occurred!
Makefile:141: recipe for target 'download_and_build' failed
```

**Note**
This issue is related with UT-CONTROL (https://github.com/rdkcentral/ut-control/issues/70 ).