### PR TITLE
TDK-10019 Enhance ut-core framework for listing test-cases

### DIFF
--- a/src/c_source/cunit_lgpl/ut_console.c
+++ b/src/c_source/cunit_lgpl/ut_console.c
@@ -562,19 +562,32 @@ static void list_tests(CU_pSuite pSuite)
   fprintf(stdout, "\n%s",
                   _("----------------- Test List ------------------------------"));
   fprintf(stdout, "\n%s%s\n", _("Suite: "), pSuite->pName);
-  fprintf(stdout, "\n%*s  %-*s%*s\n",
-                  (int)width[0], _("#"),
-                  (int)width[1], _("Test Name"),
-                  (int)width[2], _("Active?"));
 
-  for (uiCount = 1, pCurTest = pSuite->pTest ;
-       NULL != pCurTest ;
+  /* Calculate the maximum test name length */
+  unsigned int maxTestNameLength = strlen("Test Name");
+  for (pCurTest = pSuite->pTest;
+       NULL != pCurTest;
+       pCurTest = pCurTest->pNext) {
+    if (strlen(pCurTest->pName) > maxTestNameLength) {
+        maxTestNameLength = strlen(pCurTest->pName);
+    }
+  }
+
+  /* Print header with adjusted width */
+  fprintf(stdout, "\n%*s  %-*s%*s\n",
+                 (int)width[0], _("#"),
+                (int)maxTestNameLength, _("Test Name"),
+                (int)width[2], _("Active?"));
+
+  /* Print test cases without truncation */
+  for (uiCount = 1, pCurTest = pSuite->pTest;
+       NULL != pCurTest;
        uiCount++, pCurTest = pCurTest->pNext) {
     assert(NULL != pCurTest->pName);
-    fprintf(stdout, "\n%*u. %-*.*s%*s",
-                    (int)width[0], uiCount,
-                    (int)width[1], (int)width[1]-1, pCurTest->pName,
-                    (int)width[2]-1, (CU_FALSE != pCurTest->fActive) ? _("Yes") : _("No"));
+    fprintf(stdout, "\n%*u. %-*s%*s",
+            (int)width[0], uiCount,
+            (int)maxTestNameLength, pCurTest->pName,
+            (int)width[2] - 1, (CU_FALSE != pCurTest->fActive) ? _("Yes") : _("No"));
   }
   fprintf(stdout, "\n----------------------------------------------------------\n");
   fprintf(stdout, _("Total Number of Tests : %-u"), pSuite->uiNumberOfTests);


### PR DESCRIPTION
Enhance ut-core framework to print testcases properly

Test case width is hardcoded to a 34 in ut-core framework.

If the testcase name is greater than 34 , while displaying testcase name in console its truncated. 

In later version of ut-core, 34 is changed to UT_MAX_LENGTH_TEST_NAME_DISPLAYED (64) , which is not an ideal solution. 
https://github.com/rdkcentral/ut-core/commit/d5b15c7cb709d486103693d1e07c5556c782baef

Handled using dynamic approach by allocating the width by parsing through all the testcase names and setting width to maxTestNameLength.

https://jira.rdkcentral.com/jira/browse/TDK-10019