### PR TITLE
Adding changes to copy openssl and curl libraries to build/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,8 @@ framework: checkvariantchange createdirs download_and_build
 	@${ECHOE} ${GREEN}Framework downloaded and built${NC}
 	@make test VARIANT=${VARIANT}
 	@cp -r $(UT_CONTROL)/build/$(TARGET)/lib/libut_control.* $(LIB_DIR) $(BIN_DIR)
+	@cp -r $(UT_CONTROL)/build/$(TARGET)/curl/lib/libcurl.so* $(LIB_DIR) $(BIN_DIR)
+	@cp -r $(UT_CONTROL)/build/$(TARGET)/openssl/lib/lib*.so* $(LIB_DIR) $(BIN_DIR)
 	@${ECHOE} ${GREEN}ut-control LIB Copied to [${BIN_DIR}]${NC}
 	@if [ -d "$(TOP_DIR)/../include" ] && [ -d "$(BUILD_DIR)/src" ]; then \
 		${UT_CORE_DIR}/compare-functions-in-headers-testsuite.sh $(TOP_DIR)/../include $(BIN_DIR)/${TARGET_EXEC} ${TARGET}; \

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,9 @@ framework: checkvariantchange createdirs download_and_build
 	@${ECHOE} ${GREEN}Framework downloaded and built${NC}
 	@make test VARIANT=${VARIANT}
 	@cp -r $(UT_CONTROL)/build/$(TARGET)/lib/libut_control.* $(LIB_DIR) $(BIN_DIR)
+	@cp -r $(UT_CONTROL)/build/$(TARGET)/curl/lib/libcurl.so* $(LIB_DIR) $(BIN_DIR)
+	@cp -r $(UT_CONTROL)/build/$(TARGET)/openssl/lib/libssl.so* $(LIB_DIR) $(BIN_DIR)
+	@cp -r $(UT_CONTROL)/build/$(TARGET)/openssl/lib/libcrypto.so* $(LIB_DIR) $(BIN_DIR)
 	@${ECHOE} ${GREEN}ut-control LIB Copied to [${BIN_DIR}]${NC}
 	@if [ -d "$(TOP_DIR)/../include" ] && [ -d "$(BUILD_DIR)/src" ]; then \
 		${UT_CORE_DIR}/compare-functions-in-headers-testsuite.sh $(TOP_DIR)/../include $(BIN_DIR)/${TARGET_EXEC} ${TARGET}; \

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,13 @@ framework: checkvariantchange createdirs download_and_build
 	@${ECHOE} ${GREEN}Framework downloaded and built${NC}
 	@make test VARIANT=${VARIANT}
 	@cp -r $(UT_CONTROL)/build/$(TARGET)/lib/libut_control.* $(LIB_DIR) $(BIN_DIR)
-	@cp -r $(UT_CONTROL)/build/$(TARGET)/curl/lib/libcurl.so* $(LIB_DIR) $(BIN_DIR)
-	@cp -r $(UT_CONTROL)/build/$(TARGET)/openssl/lib/lib*.so* $(LIB_DIR) $(BIN_DIR)
-	@${ECHOE} ${GREEN}ut-control LIB Copied to [${BIN_DIR}]${NC}
+	@if [ -d "$(UT_CONTROL)/build/$(TARGET)/curl" ]; then \
+		@cp -r $(UT_CONTROL)/build/$(TARGET)/curl/lib/libcurl.so* $(LIB_DIR) $(BIN_DIR); \
+	fi
+	@if [ -d "$(UT_CONTROL)/build/$(TARGET)/openssl" ]; then \
+		@cp -r $(UT_CONTROL)/build/$(TARGET)/openssl/lib/lib*.so* $(LIB_DIR) $(BIN_DIR); \
+	fi
+	@${ECHOE} ${GREEN}ut-control and related LIBs Copied to [${BIN_DIR}]${NC}
 	@if [ -d "$(TOP_DIR)/../include" ] && [ -d "$(BUILD_DIR)/src" ]; then \
 		${UT_CORE_DIR}/compare-functions-in-headers-testsuite.sh $(TOP_DIR)/../include $(BIN_DIR)/${TARGET_EXEC} ${TARGET}; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,10 @@ framework: checkvariantchange createdirs download_and_build
 	@make test VARIANT=${VARIANT}
 	@cp -r $(UT_CONTROL)/build/$(TARGET)/lib/libut_control.* $(LIB_DIR) $(BIN_DIR)
 	@if [ -d "$(UT_CONTROL)/build/$(TARGET)/curl" ]; then \
-		@cp -r $(UT_CONTROL)/build/$(TARGET)/curl/lib/libcurl.so* $(LIB_DIR) $(BIN_DIR); \
+		cp -r $(UT_CONTROL)/build/$(TARGET)/curl/lib/libcurl.so* $(LIB_DIR) $(BIN_DIR); \
 	fi
 	@if [ -d "$(UT_CONTROL)/build/$(TARGET)/openssl" ]; then \
-		@cp -r $(UT_CONTROL)/build/$(TARGET)/openssl/lib/lib*.so* $(LIB_DIR) $(BIN_DIR); \
+		cp -r $(UT_CONTROL)/build/$(TARGET)/openssl/lib/lib*.so* $(LIB_DIR) $(BIN_DIR); \
 	fi
 	@${ECHOE} ${GREEN}ut-control and related LIBs Copied to [${BIN_DIR}]${NC}
 	@if [ -d "$(TOP_DIR)/../include" ] && [ -d "$(BUILD_DIR)/src" ]; then \

--- a/build.sh
+++ b/build.sh
@@ -117,7 +117,8 @@ else
         check_ut_control_revision
         # Check out the version required based on control_revision
         pushd ${UT_CONTROL_LIB_DIR} > /dev/null
-        git checkout ${UT_CONTROL_PROJECT_VERSION} # MARKER: Version=${UT_CONTROL_PROJECT_VERSION}
+        #git checkout ${UT_CONTROL_PROJECT_VERSION} # MARKER: Version=${UT_CONTROL_PROJECT_VERSION}
+        git checkout feature/gh79-ut-control-reduce-size  # MARKER: Version=${UT_CONTROL_PROJECT_VERSION}
         # Note: The above line can be modified by release test scripts to checkout a specific version or branch
         popd > /dev/null
         configure_ut_control


### PR DESCRIPTION
This change is helper for ut-control PR : https://github.com/rdkcentral/ut-control/pull/80

It focusses on copying openssl and curl libraries to build folder.