### PR TITLE
PR : gh #228 : Update ut-control to 2.0.0 in ut-core

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ popd > /dev/null # ${MY_DIR}
 # Therefore in that case it warns you but doesnt' chnage to that version, which could cause your tests to break.
 # Change this to upgrade your ut-control Major versions. Non ABI Changes 1.x.x are supported, between major revisions
 
-UT_CONTROL_PROJECT_VERSION="1.6.5"  # Fixed version
+UT_CONTROL_PROJECT_VERSION="2.0.0"  # Fixed version
 
 # Clone the Unit Test Requirements
 UT_CONTROL_REPO=git@github.com:rdkcentral/ut-control.git


### PR DESCRIPTION
Logs 

```
jpn323@janus ~/workspace/ut-core-reduce-size/tests/build/bin (feature/gh228-consume-ut-control-2.0.0)$ ./run.sh 

UT CORE Version: 4.7.3-6-g2a2174d
Listing Filename:[/tmp/ut-log_2025-12-04_161736.log-Listing.xml]
Results Filename:[/tmp/ut-log_2025-12-04_161736.log]
Setting Log Path [./logs]
Listing Filename:[./logs/ut-log_2025-12-04_161736.log-Listing.xml]
Results Filename:[./logs/ut-log_2025-12-04_161736.log]
Using Profile[./assets/test_kvp.yaml]
Using Profile[assets/config-test.yaml]
Using Profile[assets/5d.yaml]

2025-12-04-16:17:36, LOG   , ut_cunit.c,   147 : ---- start of test run ----

 ut-core: Wrapper framework for testing frameworks

***************** CUNIT CONSOLE - MAIN MENU ******************************
(R)un  (S)elect  (L)ist  (A)ctivate  (F)ailures  (O)ptions  (H)elp  (Q)uit
Enter command: r

2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   636 : Running Suite : ut-kvp - assert open / close
2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile open()'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   170 : test_ut_kvp_profile_open - start
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   172 : test_ut_kvp_profile_open - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile open()'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile getInstance()'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   217 : Check ut_kvp_profile_getInstance() - Positive
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   221 : Tested for profile : assets/test_kvp.yaml
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   228 : Tested for profile : assets/config-test.yaml
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   236 : Tested for profile : assets/5d.yaml
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile getInstance()'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile close()'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   177 : test_ut_kvp_profile_close - start
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   181 : test_ut_kvp_profile_close - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile close()'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   636 : Running Suite : ut-kvp - assert testing yaml 
2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile uint8'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    43 : test_ut_kvp_profile_uint8 - start
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    51 : test_ut_kvp_profile_uint8 - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile uint8'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile uint16'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    58 : test_ut_kvp_profile_uint16 - start
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    66 : test_ut_kvp_profile_uint16 - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile uint16'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile uint32'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    73 : test_ut_kvp_profile_uint32 - start
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    81 : test_ut_kvp_profile_uint32 - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile uint32'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile uint64'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    88 : test_ut_kvp_profile_uint64
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    96 : test_ut_kvp_profile_uint64 - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile uint64'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile string'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   103 : test_ut_kvp_profile_string
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   110 : test_ut_kvp_profile_string - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile string'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile bool'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   142 : test_ut_kvp_profile_bool
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   150 : test_ut_kvp_profile_bool - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile bool'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile list count'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   158 : test_ut_kvp_profile_list_count
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   165 : test_ut_kvp_profile_list_count - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile list count'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile right string long'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   117 : test_ut_kvp_profile_string
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   123 : test_ut_kvp_profile_string - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile right string long'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile left string long'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   130 : test_ut_kvp_profile_string
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   136 : test_ut_kvp_profile_string - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile left string long'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   636 : Running Suite : ut-kvp - assert testing json 
2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile uint8'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    43 : test_ut_kvp_profile_uint8 - start
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    51 : test_ut_kvp_profile_uint8 - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile uint8'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile uint16'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    58 : test_ut_kvp_profile_uint16 - start
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    66 : test_ut_kvp_profile_uint16 - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile uint16'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile uint32'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    73 : test_ut_kvp_profile_uint32 - start
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    81 : test_ut_kvp_profile_uint32 - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile uint32'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile uint64'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    88 : test_ut_kvp_profile_uint64
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,    96 : test_ut_kvp_profile_uint64 - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile uint64'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile string'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   103 : test_ut_kvp_profile_string
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   110 : test_ut_kvp_profile_string - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile string'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile bool'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   142 : test_ut_kvp_profile_bool
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   150 : test_ut_kvp_profile_bool - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile bool'
2025-12-04-16:17:38, LOG   , ut_console.c,   633 : 

2025-12-04-16:17:38, LOG   , ut_console.c,   639 :      Running Test : 'kvp profile list count'
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   158 : test_ut_kvp_profile_list_count
2025-12-04-16:17:38, STEP  , ut_test_kvp_profile.c,   165 : test_ut_kvp_profile_list_count - end
2025-12-04-16:17:38, LOG   , ut_console.c,   661 :      Test Complete : 'kvp profile list count'

Run Summary:    Type  Total    Ran Passed Failed Inactive
              suites      3      3    n/a      0        0
               tests     19     19     19      0        0
             asserts     70     70     70      0      n/a

Elapsed time =    0.008 seconds


***************** CUNIT CONSOLE - MAIN MENU ******************************
(R)un  (S)elect  (L)ist  (A)ctivate  (F)ailures  (O)ptions  (H)elp  (Q)uit
Enter command: q

2025-12-04-16:17:39, LOG   , ut_cunit.c,   177 : Logfile:[./logs/ut-log_2025-12-04_161736.log]
2025-12-04-16:17:39, LOG   , ut_cunit.c,   185 : ---- end of test run ----
jpn323@janus ~/workspace/ut-core-reduce-size/tests/build/bin (feature/gh228-consume-ut-control-2.0.0)$
``` 