### PR TITLE
Docs: Generalise ut-core framing — unit-testing core, not HAL-specific

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,13 @@
 
 ## 1. Purpose
 
-ut-core is the standard unit-testing framework for RDK HAL (Hardware Abstraction Layer) components. It provides:
+ut-core is the standard unit-testing core framework for RDK C/C++ components. Its primary current use is testing HAL (Hardware Abstraction Layer) implementations. It provides:
 
 - A backend-agnostic C/C++ test API that abstracts over CUnit (C path) or Google Test (C++ path).
 - A KVP (Key-Value Pair) profile system for loading YAML/JSON device configuration at runtime.
 - Three execution modes: Console (interactive), Basic (stdout), and Automated (xUnit/JUnit XML).
 - Integration with the **ut-control** support library (KVP engine, logging, control-plane helpers) and **ut-raft** (Python test orchestration).
-- A template system for bootstrapping new HAL test projects.
+- A template system for bootstrapping new test projects (e.g. HAL test suites).
 
 Repository: `https://github.com/rdkcentral/ut-core`
 License: Apache 2.0
@@ -24,7 +24,7 @@ Current version tag: **5.1.0** (latest tag on the develop branch)
 
 ```
 +--------------------------+
-|   HAL Test Binary        |  (downstream project, e.g. haltest-wifi)
+|   Test Binary            |  (downstream project, e.g. haltest-wifi)
 |   main.c                 |
 +-----------+--------------+
             |
@@ -403,7 +403,7 @@ build:
 	make -C ./ut-core
 ```
 
-The `skeletons/src` directory is supplied by the downstream HAL test project (it is not committed inside `template/ut_template/`).
+The `skeletons/src` directory is supplied by the downstream test project (it is not committed inside `template/ut_template/`).
 
 ### Downstream build.sh pattern
 
@@ -522,7 +522,7 @@ ut_template/
   tools/              # Placeholder directory for project tooling
 ```
 
-`template/api_definition_template/` provides a `build_ut.sh` script for the top-level HAL API repository to clone and trigger the test suite build.
+`template/api_definition_template/` provides a `build_ut.sh` script for the top-level API repository to clone and trigger the test suite build.
 
 ---
 
@@ -649,8 +649,8 @@ ut-core/
     gtest/<TARGET>/         # GTest source (C++ path)
     ut-control/             # ut-control subproject
   template/
-    ut_template/            # Skeleton for new HAL test projects
-    api_definition_template/ # Skeleton for HAL API repos (build_ut.sh)
+    ut_template/            # Skeleton for new test projects
+    api_definition_template/ # Skeleton for API repos (build_ut.sh)
   scripts/                  # Autogenerate + release-test helper scripts and templates
   tests/                    # Self-tests for ut-core itself (incl. demo/ examples)
   build.sh                  # Framework download script

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The `ut` for a given module is triggered from scripts / makefiles which clone th
 
 This allows the `ut-core` framework to be upgraded over time, and have independence of the `ut` unit being tested.
 
-Script templates are provided to show examples files that will be required of reach layer, starting from the component under test (e.g. the HAL).
+Script templates are provided to show example files that will be required for each layer, starting from the component under test (e.g. the HAL).
 
 Testing relationship is as follows:-
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unit Testing - Hal Testing Suite
+# ut-core - Unit Testing Core Framework
 
 | Date (DD/MM/YY)  | Comment | Document Version |
 |--------|---------|---------|
@@ -17,9 +17,9 @@ To develop a L1, L2 testing suite to support vendor deliverables. This combines 
 
 Please refer to the release notes here :- [RELEASE.md](./RELEASE.md), for information on latest releases.
 
-## HAL Scope
+## Primary Use Case — HAL Testing
 
-Each of the HALS will use the hal `UT-Core` framework, it will provide all the configuration required to support building and running a common testing environment.
+Each HAL uses the `ut-core` framework, which provides all the configuration required to support building and running a common testing environment.
 
 Each HAL component definition, will have individual cadence, specific documentation, and tagged testing suites to support them. All code is shared in the `rdkcentral` git hub.
 
@@ -42,7 +42,7 @@ The `ut` for a given module is triggered from scripts / makefiles which clone th
 
 This allows the `ut-core` framework to be upgraded over time, and have independence of the `ut` unit being tested.
 
-Script templates are provided to show examples files that will be required of reach layer, starting from the hal.
+Script templates are provided to show examples files that will be required of reach layer, starting from the component under test (e.g. the HAL).
 
 Testing relationship is as follows:-
 
@@ -297,7 +297,7 @@ export LD_LIBRARY_PATH=/usr/lib:/lib:/home/root:./
 
 or use the `run.sh`, which is in the same directory
 
-Now the hal test can be executed, `-h` for help is supported.
+Now the test binary can be executed, `-h` for help is supported.
 
 ```bash
 ./hal_test  -h
@@ -463,7 +463,7 @@ The purpose of the test level is to test the module functionality as much as pos
 
 - independent test application that will run and build without the RDK on platform
 - The application can be copied after building to a running box.
-- Application will perform the startup requirements for the section of the HAL required to test, in order to perform Black Box Testing
+- Application will perform the startup requirements for the component under test, in order to perform Black Box Testing
 - Features to be defined on whether it can be functionally tested or not.
 
 ## Autogen scripts


### PR DESCRIPTION
Closes #251

### What

Reframes the two front-door docs (`AGENTS.md`, `README.md`) so ut-core's stated **purpose** is generic (a C/C++ unit-testing core), with HAL demoted from "the purpose" to the **named primary example use case**. HAL is only ut-core's main current consumer, not its intent.

### Changes (prose only — 11 edits)

**AGENTS.md**
- Purpose line: "unit-testing framework for RDK HAL components" → "unit-testing core framework for RDK C/C++ components. Its primary current use is testing HAL implementations."
- "new HAL test projects" → "new test projects (e.g. HAL test suites)"
- Architecture diagram label "HAL Test Binary" → "Test Binary"
- "downstream HAL test project" → "downstream test project"; "top-level HAL API repository" → "top-level API repository"
- Directory-tree comments: "HAL test projects" / "HAL API repos" → "test projects" / "API repos"

**README.md**
- Title "Unit Testing - Hal Testing Suite" → "ut-core - Unit Testing Core Framework"
- Section "## HAL Scope" → "## Primary Use Case — HAL Testing"
- Softened HAL-as-purpose prose (L22, L45, L300, L466) to "component under test (e.g. the HAL)" style wording

### Deliberately NOT changed

Load-bearing identifiers and genuine HAL-domain content are untouched: default binary `hal_test`, Makefile vars `HAL_LIB_DIR` / `-lhal_xxx`, downstream repos `haltest-wifi` / `haltest-xxx`, naming conventions `hal-<component>` / `haltest-<component>`, and `docs/pages/hal_unit_testing_requirements.md` (a real HAL requirements doc, linked by name elsewhere).

`git diff` is prose-only — no code, identifiers, or intra-repo links changed.